### PR TITLE
Update version number to match 'dev-test.git'

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "inuit-tables",
-  "version": "0.0.1",
+  "version": "0.1.3",
   "authors": [
     "Harry Roberts <harry@csswizardry.com>"
   ],


### PR DESCRIPTION
'dev-test.git' references `"inuit-tables": "~0.1.1"` and in history this was called `"version": "0.1.2"` so I bumped it to `0.1.2` to avoid `bower install` errors.
