### PR TITLE
Update version of normalize dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "inuit-defaults": "~0.2.0",
     "inuit-functions": "~0.2.0",
-    "inuit-normalize": "~3.0.1"
+    "inuit-normalize": "~3.0.3"
   },
   "homepage": "https://github.com/inuitcss/objects.tables"
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "inuit-tables",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "authors": [
     "Harry Roberts <harry@csswizardry.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   "dependencies": {
     "inuit-defaults": "~0.2.0",
     "inuit-functions": "~0.2.0",
-    "inuit-normalize": "~3.0.1"
+    "inuit-normalize": "~3.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inuit-tables",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Simple tables objects for the inuitcss framework.",
   "main": "_objects.tables.scss",
   "repository": {


### PR DESCRIPTION
Having v3.0.1 as dependency for normalize causes an extra
folder in the bower_components when the a newer version of
normalize is being downloaded manually. The manually
downloaded normalize would be in "inuit-normalize.css",
whereas the automatic downloaded normalize via this packages
bower.json would be in "inuit-normalize". That leads to two
separate folders with the same code and just a different folder
name. Setting the version dependency in this package for
normalize to v3.0.3 would prevent this minor issue.

This was pointed out [here](https://github.com/inuitcss/generic.normalize/issues/7) by @sarukuku